### PR TITLE
Support for Guard 2.x plugin syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,12 @@ source "http://rubygems.org"
 # Specify your gem's dependencies in guard-annotate.gemspec
 gemspec
 
-require 'rbconfig'
+require './spec/support/platform_helper'
 
-if Config::CONFIG['target_os'] =~ /darwin/i
+if mac?
   gem 'rb-fsevent', '>= 0.3.2'
   gem 'growl',      '~> 1.0.3'
-end
-if Config::CONFIG['target_os'] =~ /linux/i
+elsif linux?
   gem 'rb-inotify', '>= 0.5.1'
   gem 'libnotify',  '~> 0.1.3'
 end

--- a/guard-annotate.gemspec
+++ b/guard-annotate.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "guard-annotate"
 
-  s.add_dependency 'guard', '< 2.0', '>= 0.2.2'
+  s.add_dependency 'guard', '~> 2.0'
   s.add_dependency 'annotate', '>= 2.4.0'
 
   s.add_development_dependency 'rspec', '~> 2.9.0'

--- a/guard-annotate.gemspec
+++ b/guard-annotate.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "guard-annotate"
 
-  s.add_dependency 'guard', '>= 0.2.2'
+  s.add_dependency 'guard', '< 2.0', '>= 0.2.2'
   s.add_dependency 'annotate', '>= 2.4.0'
 
   s.add_development_dependency 'rspec', '~> 2.9.0'

--- a/lib/guard/annotate.rb
+++ b/lib/guard/annotate.rb
@@ -1,14 +1,14 @@
 # encoding: utf-8
 require 'guard'
-require 'guard/guard'
+require 'guard/plugin'
 require 'guard/version'
 
 module Guard
-  class Annotate < Guard
+  class Annotate < Plugin
 
     autoload :Notifier, 'guard/annotate/notifier'
 
-    def initialize(watchers=[], options={})
+    def initialize(options={})
       super
 
       options[:notify] = true if options[:notify].nil?

--- a/lib/guard/annotate/version.rb
+++ b/lib/guard/annotate/version.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 module Guard
   module AnnotateVersion
-    VERSION = '1.1.0'
+    VERSION = '2.0.0'
   end
 end

--- a/spec/guard/annotate_spec.rb
+++ b/spec/guard/annotate_spec.rb
@@ -10,7 +10,7 @@ describe Guard::Annotate do
       end
 
       it "should allow notifications to be turned off" do
-        subject = Guard::Annotate.new( [], :notify => false )
+        subject = Guard::Annotate.new(:notify => false)
         subject.options[:notify].should be_false
       end
     end
@@ -21,14 +21,14 @@ describe Guard::Annotate do
       end
 
       it "should allow user to customize position (before)" do
-        subject = Guard::Annotate.new( [], :position => 'before' )
+        subject = Guard::Annotate.new(:position => 'before')
         subject.options[:position].should == 'before'
         subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
         subject.start
       end
 
       it "should allow user to customize position (after)" do
-        subject = Guard::Annotate.new( [], :position => 'after' )
+        subject = Guard::Annotate.new(:position => 'after')
         subject.options[:position].should == 'after'
         subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p after")
         subject.start
@@ -41,21 +41,21 @@ describe Guard::Annotate do
       end
 
       it "should allow the users to run routes if desired" do
-        subject = Guard::Annotate.new( [], :routes => true)
+        subject = Guard::Annotate.new(:routes => true)
         subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
         subject.should_receive(:system).with("bundle exec annotate -r -p before")
         subject.start
       end
 
       it "should allow the user to customize routes annotation position (before)" do
-        subject = Guard::Annotate.new( [], :routes => true, :position => 'before')
+        subject = Guard::Annotate.new(:routes => true, :position => 'before')
         subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
         subject.should_receive(:system).with("bundle exec annotate -r -p before")
         subject.start
       end
 
       it "should allow the user to customize routes annotation position (after)" do
-        subject = Guard::Annotate.new( [], :routes => true, :position => 'after')
+        subject = Guard::Annotate.new(:routes => true, :position => 'after')
         subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p after")
         subject.should_receive(:system).with("bundle exec annotate -r -p after")
         subject.start
@@ -68,7 +68,7 @@ describe Guard::Annotate do
       end
 
       it "should allow user to run tests and fixtures annotations if desired" do
-        subject = Guard::Annotate.new( [], :tests => true )
+        subject = Guard::Annotate.new(:tests => true)
         subject.should_receive(:system).with("bundle exec annotate  -p before")
         subject.start
       end
@@ -80,7 +80,7 @@ describe Guard::Annotate do
       end
 
       it "should allow user to sort columns by name if desired" do
-        subject = Guard::Annotate.new( [], :sort => true )
+        subject = Guard::Annotate.new(:sort => true)
         subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --sort")
         subject.start
       end
@@ -92,7 +92,7 @@ describe Guard::Annotate do
       end
 
       it "should allow user to add indexes to annotations if desired" do
-        subject = Guard::Annotate.new( [], :show_indexes => true )
+        subject = Guard::Annotate.new(:show_indexes => true)
         subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --show-indexes")
         subject.start
       end
@@ -104,7 +104,7 @@ describe Guard::Annotate do
       end
 
       it "should allow user to add simple indexes to annotations if desired" do
-        subject = Guard::Annotate.new( [], :simple_indexes => true )
+        subject = Guard::Annotate.new(:simple_indexes => true)
         subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --simple-indexes")
         subject.start
       end
@@ -116,7 +116,7 @@ describe Guard::Annotate do
       end
 
       it "should allow user to add migration version in annotations if desired" do
-        subject = Guard::Annotate.new( [], :show_migration => true )
+        subject = Guard::Annotate.new(:show_migration => true)
         subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --show-migration")
         subject.start
       end
@@ -129,7 +129,7 @@ describe Guard::Annotate do
 
       describe "invalid" do
         it "should not add format type if option given is invalid" do
-          subject = Guard::Annotate.new( [], :format => :invalid_option)
+          subject = Guard::Annotate.new(:format => :invalid_option)
           subject.options[:show_migration].should be_false
           subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before")
           subject.start
@@ -137,21 +137,21 @@ describe Guard::Annotate do
       end
       describe "bare" do
         it "should allow user to choose format of annotations if desired" do
-          subject = Guard::Annotate.new( [], :format => :bare )
+          subject = Guard::Annotate.new(:format => :bare)
           subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --format=bare")
           subject.start
         end
       end
       describe "rdoc" do
         it "should allow user to choose format of annotations if desired" do
-          subject = Guard::Annotate.new( [], :format => :rdoc )
+          subject = Guard::Annotate.new(:format => :rdoc)
           subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --format=rdoc")
           subject.start
         end
       end
       describe "markdown" do
         it "should allow user to choose format of annotations if desired" do
-          subject = Guard::Annotate.new( [], :format => :markdown )
+          subject = Guard::Annotate.new(:format => :markdown)
           subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --format=markdown")
           subject.start
         end
@@ -164,7 +164,7 @@ describe Guard::Annotate do
       end
 
       it "should allow user to opt out of running at start" do
-        subject = Guard::Annotate.new( [], :run_at_start => false)
+        subject = Guard::Annotate.new(:run_at_start => false)
         subject.options[:run_at_start].should be_false
       end
     end

--- a/spec/guard/annotate_spec.rb
+++ b/spec/guard/annotate_spec.rb
@@ -81,7 +81,7 @@ describe Guard::Annotate do
 
       it "should allow user to sort columns by name if desired" do
         subject = Guard::Annotate.new( [], :sort => true )
-        subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures --sort -p before")
+        subject.should_receive(:system).with("bundle exec annotate --exclude tests,fixtures -p before --sort")
         subject.start
       end
     end

--- a/spec/support/platform_helper.rb
+++ b/spec/support/platform_helper.rb
@@ -1,7 +1,9 @@
+require 'rbconfig'
+
 def mac?
-  Config::CONFIG['target_os'] =~ /darwin/i
+  RbConfig::CONFIG['target_os'] =~ /darwin/i
 end
 
 def linux?
-  Config::CONFIG['target_os'] =~ /linux/i
+  RbConfig::CONFIG['target_os'] =~ /linux/i
 end


### PR DESCRIPTION
Guard 2.x introduced small changes to the API that affect how Guard plugins are created. 

This PR implements the required changes that are detailed in the [Upgrading to Guard 2.0 wiki](https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0#guardguard-deprecated-in-favor-of-guardplugin).
- [x] Inheriting from `::Guard::Guard` has been deprecated in favor of `::Guard::Plugin`
- [x] The `#initialize` signature has changed

I've also bumped the version number to `2.0.0` to reflect the compatibility with Guard version.

P.S. Hope you are doing well!
